### PR TITLE
🔧 Final SDK Import Fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
  * Retains ALL async functionality: start_image_generation, check_generation_status, get_latest_image
  */
 
-const { StdioServerTransport } = require("@modelcontextprotocol/sdk/server/stdio.js");
+const { StdioServerTransport } = require("@modelcontextprotocol/sdk/server/stdio");
 const { createServer } = require('./src/core/server');
 const { CONFIG } = require('./src/core/config');
 const { ensureDownloadDirectory, cleanupFiles } = require('./src/utils/file-system');

--- a/src/core/server.js
+++ b/src/core/server.js
@@ -2,7 +2,7 @@
  * MCP Server setup - CommonJS Version
  */
 
-const { Server } = require("@modelcontextprotocol/sdk/server/index.js");
+const { Server } = require("@modelcontextprotocol/sdk/server/index");
 const { handleChatGPTTool, createErrorResponse } = require('../handlers/tool-handlers');
 
 /**


### PR DESCRIPTION
## 🔧 Final SDK Import Fix

**Fix remaining .js extensions in MCP SDK imports causing module resolution errors.**

### 🐛 Issue
The logs showed Node.js was still having trouble with:
```
require("@modelcontextprotocol/sdk/server/stdio.js")
require("@modelcontextprotocol/sdk/server/index.js")  
```

### ✅ Fix Applied
- ✅ Remove `.js` extension from MCP SDK imports in `index.js`
- ✅ Remove `.js` extension from MCP SDK imports in `src/core/server.js`

### 🎯 Result
This should completely eliminate the module resolution errors and allow the server to start properly.

**Quick test after merge:**
```bash
git pull origin main
npm install  
# Restart Claude Desktop
# Test: "Can you ask ChatGPT what the weather is like today?"
```