### PR TITLE
🔧 Revert MCP SDK Import Extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
  * Retains ALL async functionality: start_image_generation, check_generation_status, get_latest_image
  */
 
-const { StdioServerTransport } = require("@modelcontextprotocol/sdk/server/stdio");
+const { StdioServerTransport } = require("@modelcontextprotocol/sdk/server/stdio.js");
 const { createServer } = require('./src/core/server');
 const { CONFIG } = require('./src/core/config');
 const { ensureDownloadDirectory, cleanupFiles } = require('./src/utils/file-system');

--- a/src/core/server.js
+++ b/src/core/server.js
@@ -2,7 +2,7 @@
  * MCP Server setup - CommonJS Version
  */
 
-const { Server } = require("@modelcontextprotocol/sdk/server/index");
+const { Server } = require("@modelcontextprotocol/sdk/server/index.js");
 const { handleChatGPTTool, createErrorResponse } = require('../handlers/tool-handlers');
 
 /**


### PR DESCRIPTION
## 🔧 Revert MCP SDK Import Extensions

The error logs show that the MCP SDK requires the `.js` extensions to be present for proper module resolution. Reverting the SDK imports back to include `.js` extensions while keeping our internal modules without them.

### ✅ Changes
- ✅ Restore `.js` extension for `@modelcontextprotocol/sdk/server/stdio.js`
- ✅ Restore `.js` extension for `@modelcontextprotocol/sdk/server/index.js`
- ✅ Keep internal module imports without `.js` extensions

This should resolve the module resolution errors.